### PR TITLE
adapt to asav9101 when labeling jz_after_code_sign_verify_signature_image

### DIFF
--- a/asadbg_rename.py
+++ b/asadbg_rename.py
@@ -450,7 +450,7 @@ def find_lina_signature_check():
         while count <= 4:
             e = NextHead(e)
             print(GetDisasm(e))
-            if GetDisasm(e).startswith("jz"):
+            if GetDisasm(e).startswith("jz") or GetDisasm(e).startswith("jnz"):
                 MyMakeName(e, "jz_after_code_sign_verify_signature_image")
                 logmsg("jz_after_code_sign_verify_signature_image = 0x%x" % e)
                 bFound = True


### PR DESCRIPTION
In the newest image of version `asav9101`,  the jmp condition after calling `code_sign_verify_signature_image()` in `lina_monitor` binary is `jnz` instead of `jz` as the previous version.

    lea     rdi, aAsaBinLina ; "/asa/bin/lina"
    call    code_sign_verify_signature_image
    test    eax, eax
    mov     ebx, eax
    jnz     loc_3D06

So just make a little fix. Other work is done in `asafw`.